### PR TITLE
Replace HTML auto-detection with explicit {:html, string}

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Run options: `bold`, `italic`, `underline`, `strikethrough`, `superscript`, `sub
 
 ### HTML text
 
-Pass HTML strings anywhere text is accepted. Podium auto-detects HTML tags and parses them into the same internal format:
+Wrap HTML strings in `{:html, "..."}` anywhere text is accepted:
 
 ```elixir
 # HTML — compact, familiar syntax
 slide = Podium.add_text_box(slide,
-  ~s(<p>Revenue grew <span style="color: #228B22"><b>35%</b></span></p>),
+  {:html, ~s(<p>Revenue grew <span style="color: #228B22"><b>35%</b></span></p>)},
   x: {1, :inches}, y: {1, :inches}, width: {10, :inches}, height: {1, :inches})
 
 # Equivalent rich text API

--- a/demos/html-text.exs
+++ b/demos/html-text.exs
@@ -6,7 +6,8 @@ prs = Podium.new()
 s1 =
   Podium.Slide.new()
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>HTML Text Input</b></span></p>),
+    {:html,
+     ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>HTML Text Input</b></span></p>)},
     x: {0.5, :inches},
     y: {0.3, :inches},
     width: {12, :inches},
@@ -14,12 +15,12 @@ s1 =
     fill: {:gradient, [{0, "E8EDF2"}, {100_000, "FFFFFF"}], angle: 5_400_000}
   )
   |> Podium.add_text_box(
-    """
+    {:html, """
     <p><b>Bold text</b>, <i>italic text</i>, <u>underlined text</u></p>
     <p><s>Strikethrough</s>, E=mc<sup>2</sup>, H<sub>2</sub>O</p>
     <p><span style="color: #FF0000">Red</span>, <span style="color: #00AA00">Green</span>, <span style="color: #0000FF">Blue</span></p>
     <p><span style="font-family: Courier New; font-size: 14pt">Courier New at 14pt</span></p>
-    """,
+    """},
     x: {0.5, :inches},
     y: {1.5, :inches},
     width: {12, :inches},
@@ -30,7 +31,8 @@ s1 =
 s2 =
   Podium.Slide.new()
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Lists</b></span></p>),
+    {:html,
+     ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Lists</b></span></p>)},
     x: {0.5, :inches},
     y: {0.3, :inches},
     width: {12, :inches},
@@ -38,7 +40,7 @@ s2 =
     fill: {:gradient, [{0, "E8EDF2"}, {100_000, "FFFFFF"}], angle: 5_400_000}
   )
   |> Podium.add_text_box(
-    """
+    {:html, """
     <ul>
       <li>Unordered list item one</li>
       <li>Unordered list item two</li>
@@ -48,20 +50,20 @@ s2 =
       </ul>
       <li>Back to top level</li>
     </ul>
-    """,
+    """},
     x: {0.5, :inches},
     y: {1.5, :inches},
     width: {5.5, :inches},
     height: {4.5, :inches}
   )
   |> Podium.add_text_box(
-    """
+    {:html, """
     <ol>
       <li>First step</li>
       <li>Second step</li>
       <li>Third step</li>
     </ol>
-    """,
+    """},
     x: {6.5, :inches},
     y: {1.5, :inches},
     width: {5.5, :inches},
@@ -72,7 +74,8 @@ s2 =
 s3 =
   Podium.Slide.new()
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Nested Formatting</b></span></p>),
+    {:html,
+     ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Nested Formatting</b></span></p>)},
     x: {0.5, :inches},
     y: {0.3, :inches},
     width: {12, :inches},
@@ -80,12 +83,12 @@ s3 =
     fill: {:gradient, [{0, "E8EDF2"}, {100_000, "FFFFFF"}], angle: 5_400_000}
   )
   |> Podium.add_text_box(
-    """
+    {:html, """
     <p><b><i>Bold and italic combined</i></b></p>
     <p><b><u>Bold and underlined</u></b></p>
     <p><b><i><span style="color: #CC0000">Bold italic red</span></i></b></p>
     <p><span style="font-size: 24pt; font-family: Georgia; color: #003366">Large Georgia blue</span></p>
-    """,
+    """},
     x: {0.5, :inches},
     y: {1.5, :inches},
     width: {12, :inches},
@@ -96,7 +99,8 @@ s3 =
 s4 =
   Podium.Slide.new()
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Same Output, Two APIs</b></span></p>),
+    {:html,
+     ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>Same Output, Two APIs</b></span></p>)},
     x: {0.5, :inches},
     y: {0.3, :inches},
     width: {12, :inches},
@@ -105,20 +109,20 @@ s4 =
   )
   # Left side: using HTML
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><b>Via HTML</b></p>),
+    {:html, ~s(<p style="text-align: center"><b>Via HTML</b></p>)},
     x: {0.5, :inches},
     y: {1.3, :inches},
     width: {5.5, :inches},
     height: {0.5, :inches}
   )
   |> Podium.add_text_box(
-    """
+    {:html, """
     <p><b>Q4 Summary</b></p>
     <ul>
       <li>Revenue grew <span style="color: #228B22"><b>35%</b></span></li>
       <li>Customer sat at <span style="color: #4472C4"><b>88%</b></span></li>
     </ul>
-    """,
+    """},
     x: {0.5, :inches},
     y: {1.8, :inches},
     width: {5.5, :inches},
@@ -128,7 +132,7 @@ s4 =
   )
   # Right side: using rich text API (same output)
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><b>Via Rich Text API</b></p>),
+    {:html, ~s(<p style="text-align: center"><b>Via Rich Text API</b></p>)},
     x: {6.5, :inches},
     y: {1.3, :inches},
     width: {5.5, :inches},
@@ -152,7 +156,8 @@ s4 =
 s5 =
   Podium.Slide.new()
   |> Podium.add_text_box(
-    ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>HTML in Tables</b></span></p>),
+    {:html,
+     ~s(<p style="text-align: center"><span style="font-size: 28pt; color: #003366"><b>HTML in Tables</b></span></p>)},
     x: {0.5, :inches},
     y: {0.3, :inches},
     width: {12, :inches},
@@ -161,9 +166,17 @@ s5 =
   )
   |> Podium.add_table(
     [
-      ["<b>Name</b>", "<b>Status</b>", "<b>Notes</b>"],
-      ["Alice", ~s(<span style="color: #228B22"><b>Active</b></span>), "Top performer"],
-      ["Bob", ~s(<span style="color: #CC0000"><b>On Leave</b></span>), "<i>Returns March</i>"]
+      [{:html, "<b>Name</b>"}, {:html, "<b>Status</b>"}, {:html, "<b>Notes</b>"}],
+      [
+        "Alice",
+        {:html, ~s(<span style="color: #228B22"><b>Active</b></span>)},
+        "Top performer"
+      ],
+      [
+        "Bob",
+        {:html, ~s(<span style="color: #CC0000"><b>On Leave</b></span>)},
+        {:html, "<i>Returns March</i>"}
+      ]
     ],
     x: {1, :inches},
     y: {1.5, :inches},

--- a/guides/web-layer/html-text.md
+++ b/guides/web-layer/html-text.md
@@ -1,9 +1,8 @@
 # HTML Text Input
 
-Podium auto-detects HTML strings anywhere text is accepted — `add_text_box`,
-table cells, `set_placeholder`, and auto shapes. Pass an HTML string instead of
-a plain string or rich text list, and Podium parses it into the same internal
-paragraph structure.
+Wrap HTML strings in `{:html, "..."}` anywhere text is accepted — `add_text_box`,
+table cells, `set_placeholder`, and auto shapes. Podium parses the HTML into the
+same internal paragraph structure.
 
 > #### Try it yourself {: .tip}
 >
@@ -13,13 +12,13 @@ paragraph structure.
 
 ```elixir
 slide = Podium.add_text_box(slide,
-  "<p><b>Bold</b>, <i>italic</i>, and <u>underlined</u></p>",
+  {:html, "<p><b>Bold</b>, <i>italic</i>, and <u>underlined</u></p>"},
   x: {1, :inches}, y: {1, :inches},
   width: {10, :inches}, height: {1, :inches})
 ```
 
-Plain strings without any HTML tags still work exactly as before — no change
-to existing code.
+Plain strings without the `{:html, ...}` wrapper still work exactly as before —
+no change to existing code.
 
 ## Supported HTML Elements
 
@@ -51,7 +50,7 @@ Use `<span style="...">` to set color, font size, and font family on a run:
 
 ```elixir
 slide = Podium.add_text_box(slide,
-  ~s(<span style="color: #FF0000; font-size: 24pt; font-family: Arial">Styled text</span>),
+  {:html, ~s(<span style="color: #FF0000; font-size: 24pt; font-family: Arial">Styled text</span>)},
   x: {1, :inches}, y: {1, :inches},
   width: {10, :inches}, height: {1, :inches})
 ```
@@ -74,10 +73,11 @@ slide = Podium.add_text_box(slide,
 Each `<p>` becomes a separate paragraph. Set alignment with `text-align`:
 
 ```elixir
-slide = Podium.add_text_box(slide, """
+slide = Podium.add_text_box(slide,
+  {:html, """
   <p style="text-align: center"><b>Centered Title</b></p>
   <p style="text-align: left">Left-aligned body text</p>
-  """,
+  """},
   x: {1, :inches}, y: {1, :inches},
   width: {10, :inches}, height: {2, :inches})
 ```
@@ -91,7 +91,8 @@ Unordered lists (`<ul>`) produce bullet points. Ordered lists (`<ol>`) produce
 numbered items. Nesting is supported.
 
 ```elixir
-slide = Podium.add_text_box(slide, """
+slide = Podium.add_text_box(slide,
+  {:html, """
   <ul>
     <li>Revenue up 35%</li>
     <li>Customer satisfaction at all-time high</li>
@@ -99,33 +100,33 @@ slide = Podium.add_text_box(slide, """
       <li>NPS score improved across regions</li>
     </ul>
   </ul>
-  """,
+  """},
   x: {1, :inches}, y: {1, :inches},
   width: {10, :inches}, height: {3, :inches})
 ```
 
 ## HTML in Tables
 
-Table cells accept HTML strings the same way text boxes do:
+Table cells accept `{:html, "..."}` tuples the same way text boxes do:
 
 ```elixir
 slide = Podium.add_table(slide, [
-  ["<b>Name</b>", "<b>Status</b>"],
-  ["Alice", ~s(<span style="color: #228B22"><b>Active</b></span>)],
-  ["Bob", ~s(<span style="color: #CC0000"><b>On Leave</b></span>)]
+  [{:html, "<b>Name</b>"}, {:html, "<b>Status</b>"}],
+  ["Alice", {:html, ~s(<span style="color: #228B22"><b>Active</b></span>)}],
+  ["Bob", {:html, ~s(<span style="color: #CC0000"><b>On Leave</b></span>)}]
 ], x: {1, :inches}, y: {1, :inches},
    width: {10, :inches}, height: {3, :inches})
 ```
 
 ## HTML in Placeholders
 
-Placeholders also accept HTML:
+Placeholders also accept `{:html, "..."}`:
 
 ```elixir
 slide =
   Podium.Slide.new(:title_content)
-  |> Podium.set_placeholder(:title, "<b>HTML</b> Title")
-  |> Podium.set_placeholder(:content, "<ul><li>Point one</li><li>Point two</li></ul>")
+  |> Podium.set_placeholder(:title, {:html, "<b>HTML</b> Title"})
+  |> Podium.set_placeholder(:content, {:html, "<ul><li>Point one</li><li>Point two</li></ul>"})
 ```
 
 ## Rich Text API vs HTML
@@ -136,7 +137,7 @@ workflow better:
 ```elixir
 # HTML — compact, familiar to web developers
 Podium.add_text_box(slide,
-  ~s(<p>Revenue grew <span style="color: #228B22"><b>35%</b></span></p>),
+  {:html, ~s(<p>Revenue grew <span style="color: #228B22"><b>35%</b></span></p>)},
   x: {1, :inches}, y: {1, :inches},
   width: {10, :inches}, height: {1, :inches})
 
@@ -152,23 +153,6 @@ Podium.add_text_box(slide, [
 > HTML text is great when content comes from a web app or CMS. The rich text
 > API is better when you need fine-grained control over paragraph spacing,
 > line spacing, or custom bullet characters.
-
-## Detection Heuristic
-
-Podium detects HTML by checking for the presence of an HTML tag (e.g., `<b>`,
-`<span>`, `<p>`). Strings like `"5 < 10"` do not trigger HTML parsing because
-`<` followed by a space or digit is not a valid tag opener.
-
-If you have a plain string that happens to contain a valid HTML tag pattern and
-you want to prevent parsing, use the rich text list format instead:
-
-```elixir
-# This would be parsed as HTML:
-Podium.add_text_box(slide, "Use <b> for bold", ...)
-
-# Use rich text to prevent HTML parsing:
-Podium.add_text_box(slide, [["Use <b> for bold"]], ...)
-```
 
 ---
 

--- a/lib/podium.ex
+++ b/lib/podium.ex
@@ -27,15 +27,14 @@ defmodule Podium do
 
   ## Text Formatting Reference
 
-  Text content can be a plain string, an HTML string, or rich text (a list of paragraphs).
+  Text content can be a plain string, an `{:html, string}` tuple, or rich text (a list of paragraphs).
 
   ### HTML text input
 
-  Pass an HTML string anywhere text is accepted. Podium auto-detects HTML tags
-  and parses them into the same internal paragraph structure:
+  Wrap HTML strings in `{:html, "..."}` anywhere text is accepted:
 
       slide = Podium.add_text_box(slide,
-        ~s(<p><b>Bold</b> and <span style="color: #FF0000">red</span></p>),
+        {:html, ~s(<p><b>Bold</b> and <span style="color: #FF0000">red</span></p>)},
         x: {1, :inches}, y: {1, :inches}, width: {10, :inches}, height: {1, :inches})
 
   Supported elements: `<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<s>`, `<del>`,
@@ -108,7 +107,7 @@ defmodule Podium do
   @type anchor :: :top | :middle | :bottom
   @type run :: String.t() | {String.t(), keyword()}
   @type paragraph :: [run()] | {[run()], keyword()}
-  @type rich_text :: String.t() | [paragraph()]
+  @type rich_text :: String.t() | {:html, String.t()} | [paragraph()]
   @type layout ::
           :title_slide
           | :title_content

--- a/test/podium/html_test.exs
+++ b/test/podium/html_test.exs
@@ -3,38 +3,6 @@ defmodule Podium.HTMLTest do
 
   alias Podium.HTML
 
-  describe "html?/1" do
-    test "detects simple HTML tags" do
-      assert HTML.html?("<b>bold</b>")
-      assert HTML.html?("<p>paragraph</p>")
-      assert HTML.html?("<span>text</span>")
-      assert HTML.html?("<br/>")
-      assert HTML.html?("<br>")
-    end
-
-    test "detects tags with attributes" do
-      assert HTML.html?(~s(<span style="color: red">text</span>))
-      assert HTML.html?(~s(<p class="intro">text</p>))
-    end
-
-    test "rejects plain strings" do
-      refute HTML.html?("Hello world")
-      refute HTML.html?("No tags here")
-      refute HTML.html?("")
-    end
-
-    test "rejects angle brackets that aren't tags" do
-      refute HTML.html?("5 < 10 and 20 > 15")
-      refute HTML.html?("a < b")
-      refute HTML.html?("use <= operator")
-    end
-
-    test "detects self-closing tags" do
-      assert HTML.html?("<br/>")
-      assert HTML.html?("<br />")
-    end
-  end
-
   describe "parse/1 - inline formatting" do
     test "bold with <b>" do
       [para] = HTML.parse("<b>bold</b>")

--- a/test/podium/integration/html_text_integration_test.exs
+++ b/test/podium/integration/html_text_integration_test.exs
@@ -10,7 +10,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
       slide =
         Podium.Slide.new()
         |> Podium.add_text_box(
-          "<p><b>Bold title</b></p><p>Some <i>italic</i> text</p>",
+          {:html, "<p><b>Bold title</b></p><p>Some <i>italic</i> text</p>"},
           x: {1, :inches},
           y: {1, :inches},
           width: {10, :inches},
@@ -39,7 +39,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
 
       slide =
         Podium.Slide.new()
-        |> Podium.add_text_box(html,
+        |> Podium.add_text_box({:html, html},
           x: {1, :inches},
           y: {1, :inches},
           width: {10, :inches},
@@ -63,7 +63,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
 
       slide =
         Podium.Slide.new()
-        |> Podium.add_text_box(html,
+        |> Podium.add_text_box({:html, html},
           x: {1, :inches},
           y: {1, :inches},
           width: {10, :inches},
@@ -86,7 +86,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
 
       slide =
         Podium.Slide.new()
-        |> Podium.add_text_box(html,
+        |> Podium.add_text_box({:html, html},
           x: {1, :inches},
           y: {1, :inches},
           width: {10, :inches},
@@ -107,7 +107,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
 
       slide =
         Podium.Slide.new()
-        |> Podium.add_text_box(html,
+        |> Podium.add_text_box({:html, html},
           x: {1, :inches},
           y: {1, :inches},
           width: {10, :inches},
@@ -130,8 +130,8 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
   describe "HTML in table cells" do
     test "creates valid pptx with HTML in table cells" do
       rows = [
-        ["Header", "<b>Bold Header</b>"],
-        ["Plain cell", "<i>Italic</i> and <b>bold</b>"]
+        ["Header", {:html, "<b>Bold Header</b>"}],
+        ["Plain cell", {:html, "<i>Italic</i> and <b>bold</b>"}]
       ]
 
       slide =
@@ -163,8 +163,11 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
     test "creates valid pptx with HTML in placeholder" do
       slide =
         Podium.Slide.new(:title_content)
-        |> Podium.set_placeholder(:title, "<b>HTML</b> Title")
-        |> Podium.set_placeholder(:content, "<ul><li>Point one</li><li>Point two</li></ul>")
+        |> Podium.set_placeholder(:title, {:html, "<b>HTML</b> Title"})
+        |> Podium.set_placeholder(
+          :content,
+          {:html, "<ul><li>Point one</li><li>Point two</li></ul>"}
+        )
 
       prs = Podium.new() |> Podium.add_slide(slide)
 
@@ -190,7 +193,7 @@ defmodule Podium.Integration.HTMLTextIntegrationTest do
           y: {2, :inches},
           width: {8, :inches},
           height: {3, :inches},
-          text: "<p><b>Important!</b></p><p>This is <i>styled</i> text in a shape.</p>",
+          text: {:html, "<p><b>Important!</b></p><p>This is <i>styled</i> text in a shape.</p>"},
           fill: "E8EDF2"
         )
 

--- a/test/podium/text_test.exs
+++ b/test/podium/text_test.exs
@@ -41,38 +41,39 @@ defmodule Podium.TextTest do
     end
   end
 
-  describe "normalize/2 with HTML strings" do
-    test "HTML string is auto-detected and parsed" do
-      result = Text.normalize("<b>Bold</b> text")
-      assert [%{runs: [%{text: "Bold", opts: [bold: true]}, %{text: " text", opts: []}]}] = result
+  describe "normalize/2 with {:html, ...}" do
+    test "HTML tagged tuple is parsed" do
+      result = Text.normalize({:html, "<b>Bold</b> text"})
+
+      assert [%{runs: [%{text: "Bold", opts: [bold: true]}, %{text: " text", opts: []}]}] =
+               result
     end
 
     test "HTML with default alignment applied" do
-      result = Text.normalize("<p>Hello</p>", alignment: :center)
+      result = Text.normalize({:html, "<p>Hello</p>"}, alignment: :center)
       assert [%{alignment: :center}] = result
     end
 
     test "HTML with explicit alignment overrides default" do
-      result = Text.normalize(~s(<p style="text-align: right">Hello</p>), alignment: :center)
+      result =
+        Text.normalize({:html, ~s(<p style="text-align: right">Hello</p>)}, alignment: :center)
+
       assert [%{alignment: :right}] = result
     end
 
     test "HTML with default font_size applied to runs without explicit size" do
-      result = Text.normalize("<b>Bold</b>", font_size: 24)
+      result = Text.normalize({:html, "<b>Bold</b>"}, font_size: 24)
       assert [%{runs: [%{text: "Bold", opts: opts}]}] = result
       assert opts[:font_size] == 24
       assert opts[:bold] == true
     end
 
     test "HTML run with explicit font_size not overridden by default" do
-      result = Text.normalize(~s(<span style="font-size: 18pt">Sized</span>), font_size: 24)
+      result =
+        Text.normalize({:html, ~s(<span style="font-size: 18pt">Sized</span>)}, font_size: 24)
+
       assert [%{runs: [%{text: "Sized", opts: opts}]}] = result
       assert opts[:font_size] == 18
-    end
-
-    test "plain string without HTML tags uses existing path" do
-      result = Text.normalize("No tags here")
-      assert [%{runs: [%{text: "No tags here", opts: []}]}] = result
     end
   end
 


### PR DESCRIPTION
## Summary

- Replaces `html?/1` auto-detection with an explicit `{:html, "..."}` tagged tuple API — users opt in to HTML parsing rather than relying on a heuristic
- Fixes a crash in `parse_font_size` when malformed px values produce `nil`
- Performance: replaces `list ++ [element]` with prepend-and-reverse for run accumulation and list stack operations
- Removes dead code (`build_run_opts/1`, `merge_inline_opts/2`) and applies style consistency fixes