### PR TITLE
Add Phase 2c (extended CSS style properties) to ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -328,6 +328,19 @@ Implemented. `{:html, string}` tuples are accepted anywhere text is accepted —
 
 Implemented. `{value, :percent}` works in all `add_*` functions for x/y/width/height. Percent values resolve against slide dimensions (width for x/width, height for y/height) at build time — domain modules and XML rendering are unaffected. CSS-style string positioning (`style: "left: 10%; ..."`) remains a future option.
 
+### Phase 2c — Extended CSS Style Properties (Layer 2)
+
+Extend the `style:` parser to support non-positional CSS properties, mapping familiar CSS to existing Podium keyword opts:
+
+| CSS Property | Podium Option | Example |
+|-------------|---------------|---------|
+| `text-align` | `:alignment` | `text-align: center` → `alignment: :center` |
+| `vertical-align` | `:anchor` | `vertical-align: middle` → `anchor: :middle` |
+| `background` | `:fill` | `background: #FF0000` → `fill: "FF0000"` |
+| `padding` | `:margin_*` | `padding: 12pt` → margin opts |
+
+This keeps the `style:` string as a single entry point for the most common element properties, reducing the mix of CSS strings and Elixir keywords.
+
 ### Phase 3 — Chart Table Input (Layer 2)
 
 Add pipe-delimited string parsing to `ChartData`. Implement as `Podium.Chart.ChartData.from_table/2`.


### PR DESCRIPTION
Adds Phase 2c to the ROADMAP for extending the `style:` parser to cover non-positional CSS properties (`text-align`, `vertical-align`, `background`, `padding`). Tracked in #13.